### PR TITLE
Added missing dependency for Fedora

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ This should get you started on Fedora:
 
 ::
 
-    yum install python3-pip python3-devel libffi-devel gcc git
+    yum install python3-pip python3-devel libffi-devel gcc git redhat-rpm-config
 
 Installation
 ============


### PR DESCRIPTION
When building cffi after installing the given dependencies on Fedora 23, the build fails with
gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
